### PR TITLE
docs: Release v3.6.X also works on latest StartAllBack 3.8.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <br/>
 
 > PyPass-SAB is a patcher written in python that allows bypassing and resetting the **100 days remaining limit**
-> of StartAllBack. This patcher supports versions between **v3.5.5** and **v3.7.X**. Other versions may work but are not
+> of StartAllBack. This patcher supports versions between **v3.5.5** and **v3.8.10**. Other versions may work but are not
 > tested.<br/>
 
 <div align="center">


### PR DESCRIPTION
StartAllBack was just recently updated on my machine. Tried the latest release v3.6.X of the 3rd Jul and it works.


Simple `readme.md` docs version bump